### PR TITLE
fix: zeroed initCount property

### DIFF
--- a/lib/lc.js
+++ b/lib/lc.js
@@ -24,7 +24,7 @@ function add(f, n) {
   suite.add({
     name: f.name,
     minSamples: n,
-    initCount: 1,
+    initCount: 0, // https://benchmarkjs.com/docs#options_initCount
     minTime: -Infinity,
     maxTime: -Infinity,
     fn: f,


### PR DESCRIPTION
According benchmark docs this is the default number of times to
execute a test on a benchmark’s first cycle.

We want it zero to avoid calling functions twice.