### PR TITLE
fix: ensure that async function execution is waited for

### DIFF
--- a/lib/lc.js
+++ b/lib/lc.js
@@ -38,11 +38,12 @@ function run(t, pr, a) {
   suite.on(CYCLE, function onCycle(event) {
     benchmarks.add(event.target);
   });
-  suite.on(COMPLETE, function onComplete(event) {
+  suite.on(COMPLETE, async function onComplete(event) {
     benchmarks.log();
+
     if (pr) {
       console.log('\x1b[36m%s\x1b[0m', 'Function executed again. The return value is:');
-      console.log('\x1b[36m%s\x1b[0m', event.target.fn());
+      console.log('\x1b[36m%s\x1b[0m', await event.target.fn());
     }
   });
   suite.run({ async: a || false });


### PR DESCRIPTION
This commit makes the benchmark `onComplete` function async and waits for any
potential return values from the benchmarked function. If an async function is
under test, then the `await` keyword ensures that the value of the returned
`Promise` is logged. If the function under test is not async, the `async`
keyword essentially has no effect except under the covers where the function's
return value is converted to a resolved `Promise` and the resolved value is logged.